### PR TITLE
Convert RGBA to HEX and toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:extension.convertToRGBA"
+    "onCommand:extension.convertToRGBA",
+    "onCommand:extension.convertToHEX",
+    "onCommand:extension.toggleHEX"
   ],
   "main": "./out/extension",
   "contributes": {
@@ -22,6 +24,14 @@
       {
         "command": "extension.convertToRGBA",
         "title": "Convert Hex to RGBA"
+      },
+      {
+        "command": "extension.convertToHEX",
+        "title": "Convert RGBA to HEX"
+      },
+      {
+        "command": "extension.toggleHEX",
+        "title": "Toggle between HEX and RGBA"
       }
     ],
     "keybindings": [

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,0 +1,28 @@
+import * as HexAndRgba from 'hex-and-rgba';
+
+const HexToRgba = HexAndRgba.hexToRgba;
+const RgbaToHex = HexAndRgba.rgbaToHex;
+const RgbaToArray = HexAndRgba.rgbaToArray;
+const IsValidHex = HexAndRgba.isValidHex;
+const IsValidRGBA = args => !!rgbaToHex(args);
+
+export const hexToRgba = (value: string) => {
+  const [hex, opacity] = value.split('_');
+  let rgba = HexToRgba(hex);
+  if (opacity) {
+    rgba[rgba.length - 1] = Number(opacity) / 100;
+  }
+  return `rgba(${rgba[0]},${rgba[1]},${rgba[2]},${rgba[3].toPrecision(2)})`;
+};
+
+export const rgbaToHex = (rgba: string | number[]) => {
+  let hex = Array.isArray(rgba)
+    ? RgbaToHex(rgba)
+    : RgbaToHex(RgbaToArray(rgba));
+  return hex.toString();
+};
+
+export const toggleHexRgba = (value: string | number[]) => {
+  if (IsValidHex(value)) return hexToRgba(value as string);
+  if (IsValidRGBA(value)) return rgbaToHex(value);
+};

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -9,14 +9,42 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
+import * as converter from '../converter';
 import * as myExtension from '../extension';
 
 // Defines a Mocha test suite to group tests of similar kind together
-suite("Extension Tests", () => {
+suite('Extension Tests', () => {
+  test('Convert RGBA string with 20% opacity to 8-digit HEX', () => {
+    const hex = converter.rgbaToHex('rgba(75,95,130,0.20)');
+    assert.equal(hex, '#4b5f8233');
+  });
 
-    // Defines a Mocha unit test
-    test("Something 1", () => {
-        assert.equal(-1, [1, 2, 3].indexOf(5));
-        assert.equal(-1, [1, 2, 3].indexOf(0));
-    });
+  test('Convert RGBA array with 20% opacity to 8-digit HEX', () => {
+    const hex = converter.rgbaToHex([75, 95, 130, 0.2]);
+    assert.equal(hex, '#4b5f8233');
+  });
+
+  test('Convert 8-digit HEX to RGBA with 31% opacity', () => {
+    const hex = converter.hexToRgba('#030d204f');
+    assert.equal(hex, 'rgba(3,13,32,0.31)');
+  });
+
+  test('Convert 6-digit HEX with 20% opacity postfix to RGBA', () => {
+    const hex = converter.hexToRgba('#4b5f82_20');
+    assert.equal(hex, 'rgba(75,95,130,0.20)');
+  });
+
+  test('Toggle RGBA with 20% opacity to 8-digit HEX', () => {
+    const originalRGBA = 'rgba(75,95,130,0.2)';
+
+    const hex = converter.toggleHexRgba(originalRGBA);
+    assert.equal(hex, '#4b5f8233');
+  });
+
+  test('Toggle 8-digit HEX to RGBA with 31% opacity', () => {
+    const originalHEX = '#030d204f';
+
+    const rgba = converter.toggleHexRgba(originalHEX);
+    assert.equal(rgba, 'rgba(3,13,32,0.31)');
+  });
 });

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -15,8 +15,8 @@ import * as testRunner from 'vscode/lib/testrunner';
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
-    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
-    useColors: true // colored output from test results
+  ui: 'tdd', // the TDD UI is being used in extension.test.ts (suite, test, etc.)
+  useColors: true // colored output from test results
 });
 
 module.exports = testRunner;


### PR DESCRIPTION
- Added functionality to convert RGBA to HEX and toggle between them
- Extracted conversion methods to a seperate 'converter' module/file
- Added command 'convertToHEX' which converts RGBA to HEX
- Added command 'toggleHEX' which toggles between HEX and RGBA
- Removed unused Mocha test